### PR TITLE
Add multiqc and cufflinks in eba2017_rnaseq_ref.yaml

### DIFF
--- a/conda-environment/eba2017_rnaseq_ref.yaml
+++ b/conda-environment/eba2017_rnaseq_ref.yaml
@@ -12,3 +12,4 @@ dependencies:
 - bioconda::salmon=0.8.2=1
 - bioconda::star=2.5.3a=0
 - bioconda::subread=1.5.3=0
+- bioconda::multiqc

--- a/conda-environment/eba2017_rnaseq_ref.yaml
+++ b/conda-environment/eba2017_rnaseq_ref.yaml
@@ -13,3 +13,4 @@ dependencies:
 - bioconda::star=2.5.3a=0
 - bioconda::subread=1.5.3=0
 - bioconda::multiqc
+- bioconda::cufflinks


### PR DESCRIPTION
Ajout de l'outil multiqc dans eba2017_rnaseq_ref : 

ping @OvoiDs @julozi 

Procedure d'ajout:
```bash
source activate eba2017_rnaseq_ref
conda install multiqc
```

Check si OK
- [x] Roscoff
- [ ] IGR
- [ ] Strasbourg
